### PR TITLE
Install setuptools on project init

### DIFF
--- a/src/com/koxudaxi/rye/Rye.kt
+++ b/src/com/koxudaxi/rye/Rye.kt
@@ -207,8 +207,10 @@ fun setupRyeSdkUnderProgress(project: Project?,
  */
 fun setupRye(projectPath: @SystemDependent String, python: String?, installPackages: Boolean, init: Boolean) {
     when {
-        init -> { runRye(projectPath, *listOf("init").toTypedArray())
-        runRye(projectPath, *listOf("sync").toTypedArray())
+        init -> {
+            runRye(projectPath, *listOf("init").toTypedArray())
+            runRye(projectPath, *listOf("add", "--dev", "setuptools").toTypedArray())
+            runRye(projectPath, *listOf("sync").toTypedArray())
         }
         installPackages -> {
             runRye(projectPath, *listOf("sync").toTypedArray())


### PR DESCRIPTION
Currently, PyCharm complains about missing setuptools. This change will add setuptools as a dev dependency, and prevent the notice from PyCharm.